### PR TITLE
Remove _build_instance_domain's param_func argument

### DIFF
--- a/pmdahdb_test.py
+++ b/pmdahdb_test.py
@@ -4,6 +4,7 @@ import unittest
 from configparser import MissingSectionHeaderError
 
 from cpmapi import PM_ERR_AGAIN, PM_ERR_INST, PM_ERR_PMID
+
 from pmdahdb import (
     _HANA2_SPS_01,
     _HANA2_SPS_04,


### PR DESCRIPTION
Instead of recovering an instance's identifying parameters from a concatenated
string, the parameters are now stored explicitly as map.